### PR TITLE
Handle case where no bluetooth adapters available

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -123,7 +123,6 @@ public class Bluetooth.MainView : Switchboard.SettingsPage {
         update_description ();
 
         status_switch.active = manager.is_powered;
-        status_switch.visible = manager.has_object;
 
         /* Now retrieve finished, we can connect manager signals */
         manager.device_added.connect (on_device_added);
@@ -156,7 +155,7 @@ public class Bluetooth.MainView : Switchboard.SettingsPage {
 
         manager.bind_property ("is-discovering", discovery_spinner, "spinning", DEFAULT);
         manager.bind_property ("is-powered", status_switch, "active", GLib.BindingFlags.DEFAULT);
-        manager.bind_property ("has-object", status_switch, "visible", GLib.BindingFlags.DEFAULT);
+        manager.bind_property ("has-object", status_switch, "visible", GLib.BindingFlags.SYNC_CREATE);
     }
 
     private void on_device_added (Services.Device device) {

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -103,11 +103,8 @@ public class Bluetooth.MainView : Switchboard.SettingsPage {
         child = box;
 
         manager = Bluetooth.Services.ObjectManager.get_default ();
-        if (manager.retrieve_finished) {
-            complete_setup ();
-        } else {
-            manager.notify["retrieve-finished"].connect (complete_setup);
-        }
+        complete_setup ();
+        manager.notify["retrieve-finished"].connect (complete_setup);
 
         list_box.row_activated.connect ((row) => {
             ((DeviceRow) row).on_activate.begin ();
@@ -126,6 +123,7 @@ public class Bluetooth.MainView : Switchboard.SettingsPage {
         update_description ();
 
         status_switch.active = manager.is_powered;
+        status_switch.visible = manager.has_object;
 
         /* Now retrieve finished, we can connect manager signals */
         manager.device_added.connect (on_device_added);
@@ -152,8 +150,13 @@ public class Bluetooth.MainView : Switchboard.SettingsPage {
             update_description ();
         });
 
+        manager.notify["has-object"].connect (() => {
+            update_description ();
+        });
+
         manager.bind_property ("is-discovering", discovery_spinner, "spinning", DEFAULT);
         manager.bind_property ("is-powered", status_switch, "active", GLib.BindingFlags.DEFAULT);
+        manager.bind_property ("has-object", status_switch, "visible", GLib.BindingFlags.DEFAULT);
     }
 
     private void on_device_added (Services.Device device) {
@@ -210,20 +213,24 @@ public class Bluetooth.MainView : Switchboard.SettingsPage {
     private void update_description () {
         string? name = manager.get_name ();
         var powered = manager.is_powered;
-        if (powered && manager.discoverable) {
+        var available = manager.has_object;
+        if (powered && manager.discoverable && available) {
             //TRANSLATORS: \"%s\" represents the name of the adapter
             description = _("Now discoverable as \"%s\". Not discoverable when this page is closed").printf (name ?? _("Unknown"));
         } else if (!powered) {
             description = _("Not discoverable while Bluetooth is powered off");
+        } else if (!available) {
+            description = _("No Bluetooth adapters available");
         } else {
             description = _("Not discoverable");
         }
 
-        if (powered) {
+        if (powered && available) {
             icon = new ThemedIcon ("bluetooth");
         } else {
             icon = new ThemedIcon ("bluetooth-disabled");
         }
+        child.visible = available;
     }
 
     private Gtk.Widget create_widget_func (Object obj) {

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -325,9 +325,9 @@ public class Bluetooth.Services.ObjectManager : Object {
 
     public async void start_discovery () {
         var adapters = get_adapters ();
-        is_discovering = true;
         foreach (var adapter in adapters) {
             try {
+                is_discovering = true;
                 yield adapter.start_discovery ();
                 debug ("Adapter %s started", adapter.name);
             } catch (Error e) {

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -325,9 +325,9 @@ public class Bluetooth.Services.ObjectManager : Object {
 
     public async void start_discovery () {
         var adapters = get_adapters ();
+        is_discovering = adapters.size > 0;
         foreach (var adapter in adapters) {
             try {
-                is_discovering = true;
                 yield adapter.start_discovery ();
                 debug ("Adapter %s started", adapter.name);
             } catch (Error e) {


### PR DESCRIPTION
Proposing the following visual change:

When bluetooth adapter(s) are available/enabled, look and work as before:

<img width="1776" height="1112" alt="bluetooth-available" src="https://github.com/user-attachments/assets/1cd89cbd-6659-47aa-b474-ea404035e335" />


When no bluetooth adapters available or it's disabled altogether:

<img width="1576" height="1144" alt="bluetooth-unavailable" src="https://github.com/user-attachments/assets/3f69ab5e-8b9a-418f-9791-ff513930b0c8" />


CAVEAT: Note I've only tested on my desktop PC with onboard bluetooth which I enable/disable in the UEFI settings then reboot into the OS, I don't have a USB adapter to test scenarios like plugging in and unplugging it to see if the settings update/work as expected. I do have a laptop but don't think it has a switch to enable/disable bluetooth on the fly.
